### PR TITLE
Create run_script.yml

### DIFF
--- a/.github/workflows/run_script.yml
+++ b/.github/workflows/run_script.yml
@@ -1,0 +1,28 @@
+name: Run Python Script in Codespaces
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run-script:
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/vscode/devcontainers/python:0-3.8
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install azure-cognitiveservices-speech python-dotenv
+
+    - name: Run script
+      env:
+        SPEECH_KEY: ${{ secrets.SPEECH_KEY }}
+        SERVICE_REGION: ${{ secrets.SERVICE_REGION }}
+      run: python transcribebak.py


### PR DESCRIPTION
This pull request introduces a new GitHub workflow in the `.github/workflows/run_script.yml` file. The workflow is designed to run a Python script in GitHub Codespaces. It's triggered manually through the `workflow_dispatch` event. The workflow runs on an `ubuntu-latest` environment with a Python 3.8 container. It includes steps to checkout the code, setup Python, install dependencies, and finally run the script `transcribebak.py` with certain environment variables.

* [`.github/workflows/run_script.yml`](diffhunk://#diff-c3735386aeadab35a2fed861387aff5347012e4d903d7c8a1879f2b57350a65aR1-R28): Added a new GitHub workflow to run a Python script in GitHub Codespaces. The workflow is triggered manually, runs on an `ubuntu-latest` environment with a Python 3.8 container, and includes steps to checkout the code, setup Python, install dependencies, and run the script `transcribebak.py` with environment variables `SPEECH_KEY` and `SERVICE_REGION`.